### PR TITLE
Switch to using gradle

### DIFF
--- a/azure.gradle
+++ b/azure.gradle
@@ -1,0 +1,21 @@
+import java.util.regex.Pattern
+
+def doExtractStringFromManifest(name) {
+    def manifestFile = file(android.sourceSets.main.manifest.srcFile)
+    def pattern = Pattern.compile(name + "=\"(.*?)\"")
+    def matcher = pattern.matcher(manifestFile.getText())
+    matcher.find()
+    return matcher.group(1)
+}
+
+android {
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+        }
+    }
+
+    defaultConfig {
+        applicationId = doExtractStringFromManifest("package")
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@
             <meta-data android:name="engagement:reach:notification:icon" android:value="$AZME_ANDROID_REACH_ICON"/>
             <!-- If only 1 sender, don't forget the \n, otherwise it will be parsed as a negative number... -->
             <meta-data android:name="engagement:gcm:sender" android:value="$AZME_ANDROID_GOOGLE_PROJECT_NUMBER\n"/>
-            <service android:exported="false" android:label="$PACKAGE_NAME-Service" android:name="com.microsoft.azure.engagement.service.EngagementService" android:process=":Engagement"/>
+            <service android:exported="false" android:label="${applicationId}-Service" android:name="com.microsoft.azure.engagement.service.EngagementService" android:process=":Engagement"/>
             <meta-data android:name="engagement:log:test" android:value="$AZME_ENABLE_NATIVE_LOG"/>
              <meta-data android:name="AZME_ENABLE_PLUGIN_LOG" android:value="$AZME_ENABLE_PLUGIN_LOG"/>
             <meta-data android:name="engagement:reach:notification:icon" android:value="$AZME_ANDROID_REACH_ICON"/>
@@ -106,7 +106,7 @@
                 <intent-filter>
                     <action android:name="com.google.android.c2dm.intent.REGISTRATION"/>
                     <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
-                    <category android:name="$PACKAGE_NAME"/>
+                    <category android:name="${applicationId}"/>
                 </intent-filter>
             </receiver>
             <receiver android:name="com.microsoft.azure.engagement.shared.EngagementDataPushReceiver"
@@ -133,14 +133,15 @@
             <uses-permission android:name="android.permission.VIBRATE"/>
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
             <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
-            <uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
-            <permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
+            <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE"/>
+            <permission android:name="${applicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
         </config-file>
         <source-file src="src/android/cordova/AZME.java" target-dir="src/com/microsoft/azure/engagement/cordova"/>
         <source-file src="src/android/shared/EngagementDataPushReceiver.java" target-dir="src/com/microsoft/azure/engagement/shared"/>
         <source-file src="src/android/shared/EngagementShared.java" target-dir="src/com/microsoft/azure/engagement/shared"/>
         <source-file src="src/android/shared/EngagementDelegate.java" target-dir="src/com/microsoft/azure/engagement/shared"/>
         <source-file src="src/android/EngagementSDK/mobile-engagement-4.1.0.jar" target-dir="libs"/>
+        <framework src="azure.gradle" custom="true" type="gradleReference" />
         <framework src="com.android.support:support-v4:+" />
         <source-file src="src/android/EngagementSDK/res/drawable/engagement_close.png" target-dir="res/drawable"/>
         <source-file src="src/android/EngagementSDK/res/drawable/engagement_content_title.xml" target-dir="res/drawable"/>
@@ -185,7 +186,7 @@
                     <key>CFBundleTypeRole</key>
                     <string>None</string>
                     <key>CFBundleURLName</key>
-                    <string>$PACKAGE_NAME.redirect</string>
+                    <string>${applicationId}.redirect</string>
                     <key>CFBundleURLSchemes</key>
                     <array>
                         <string>$AZME_ACTION_URL</string>


### PR DESCRIPTION
The old way of using $PACKAGE_NAME can cause problems if two plugins are using the same permission. Switching to gradle to determine the application ID fixes the issue. See https://github.com/phonegap/phonegap-plugin-push/issues/481 for more information.