### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,18 @@
       "windows"
     ]
   },
+  "engines": {
+    "cordovaDependencies": {
+      "3.2.0": {
+        "cordova": ">=5.2.0",
+        "cordova-android": ">=5.0.0",
+        "cordova-ios": ">=3.9.2"
+      },
+      "4.0.0": {
+        "cordova": ">100"
+      }
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-mobile-engagement-cordova"


### PR DESCRIPTION
This reflects `engines` elements from plugin manifest to package.json to comply w/ [new plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md).

Its also desirable to add 'protective' entry for next major plugin version to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. See corresponding [discussion on mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5) for more details and reasons behind this.